### PR TITLE
[BACKLOG-11621] Removes JTDS and JCIFS drivers from classpath

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -143,7 +143,6 @@
 	<classpathentry kind="lib" path="lib/jaxen-1.1.jar" />
 	<classpathentry kind="lib" path="lib/jaxws-spring-1.8.jar" />
 	<classpathentry kind="lib" path="lib/jaybird-full-2.1.0.jar" />
-	<classpathentry kind="lib" path="lib/jcifs-1.3.3.jar" />
 	<classpathentry kind="lib" path="lib/jcl-over-slf4j-1.5.8.jar" />
 	<classpathentry kind="lib" path="lib/jcommon-1.0.14.jar" />
 	<classpathentry kind="lib" path="lib/jcr-1.0.jar" />
@@ -174,7 +173,6 @@
 	<classpathentry kind="lib" path="lib/jstl-1.0.5.jar" />
 	<classpathentry kind="lib" path="lib/jt400-6.1.jar" />
 	<classpathentry kind="lib" path="lib/jta-1.1.jar" />
-	<classpathentry kind="lib" path="lib/jtds-1.2.5.jar" />
 	<classpathentry kind="lib" path="lib/jug-lgpl-2.0.0.jar" />
 	<classpathentry kind="lib" path="lib/jxl-2.6.10.jar" />
 	<classpathentry kind="lib" path="lib/jzlib-1.0.7.jar" />


### PR DESCRIPTION
@CodeOnCoffee @rmansoor @mbatchelor @pentaho/rogueone Please review

Related PRs:
https://github.com/pentaho/pentaho-platform/pull/3207
https://github.com/pentaho/pentaho-reporting/pull/869
https://github.com/pentaho/pentaho-reportdesigner-ee/pull/53
https://github.com/pentaho/pentaho-kettle/pull/3087
https://github.com/pentaho/pdi-platform-plugin/pull/40
https://github.com/pentaho/pentaho-platform-migrator/pull/323
https://github.com/pentaho/big-data-plugin/pull/761