### PR TITLE
[BACKLOG-12101] Mavenizing platform

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -28,7 +28,9 @@
         </dependency>
 
         <!--  test dependencies -->
-        <dependency org="pentaho" name="pentaho-platform-core-test" rev="${dependency.pentaho-platform.revision}"  changing="true" conf="test->default"/>
+        <dependency org="pentaho" name="pentaho-platform-core" rev="${dependency.pentaho-platform.revision}"  changing="true" conf="test->default">
+			<artifact name="pentaho-platform-core" ext="jar" m:classifier="tests"/>
+        </dependency>
         <dependency org="junit" name="junit" rev="4.4" conf="test->default" />
         <dependency org="org.hsqldb" name="hsqldb" rev="2.3.2" conf="test->default" transitive="false"/>
         <dependency org="org.mockito" name="mockito-all" rev="1.10.19" conf="test->default"/>


### PR DESCRIPTION
	-Updated the dependency on platform-core-test to use m:classifier
	as platform-core-test has been mavenized

only merge after https://github.com/pedrofvteixeira/pentaho-platform/tree/BACKLOG-12101 merge