### PR TITLE
[PDI-17398] Scheduling a Job More than Once Causes the Logs to Displa…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiAction.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiAction.java
@@ -635,8 +635,8 @@ public class PdiAction implements IAction, IVarArgsAction, ILoggingAction, RowLi
   }
 
   @VisibleForTesting
-  Job newJob( Repository repository, JobMeta jobMeta ) {
-    return new Job( repository, jobMeta );
+  Job newJob( Repository repository, JobMeta jobMeta, String carteObjectId ) {
+    return new Job( repository, jobMeta, carteObjectId );
   }
 
   /**
@@ -745,11 +745,10 @@ public class PdiAction implements IAction, IVarArgsAction, ILoggingAction, RowLi
       }
 
       try {
-        localJob = newJob( repository, jobMeta );
+        String carteObjectId = UUID.randomUUID().toString();
+        localJob = newJob( repository, jobMeta, carteObjectId );
         localJob.setArguments( arguments );
         localJob.shareVariablesWith( jobMeta );
-        String carteObjectId = UUID.randomUUID().toString();
-        localJob.setContainerObjectId( carteObjectId );
         CarteSingleton.getInstance().getJobMap().addJob( getJobName( carteObjectId ), carteObjectId, localJob,
             new JobConfiguration( localJob.getJobMeta(), jobExConfig ) );
 

--- a/core/src/test/java/org/pentaho/platform/plugin/kettle/PdiActionTest.java
+++ b/core/src/test/java/org/pentaho/platform/plugin/kettle/PdiActionTest.java
@@ -416,7 +416,7 @@ public class PdiActionTest {
     action.setExpandingRemoteJob( TEST_FALSE_BOOLEAN_PARAM );
     action.setStartCopyName( TEST_START_COPY_NAME_PARAM );
 
-    doReturn( job ).when( action ).newJob( repository, meta );
+    doReturn( job ).when( action ).newJob( repository, meta, null );
     doReturn( false ).when( log ).isDebugEnabled();
     doReturn( jobExecutionConfiguration ).when( action ).newJobExecutionConfiguration();
     doReturn( result ).when( job ).getResult();


### PR DESCRIPTION
…y Incorrectly

When creating a new `Job`, specify the Carte object Id in the constructor so it is available before the log channel is created. This needs to be merged after https://github.com/pentaho/pentaho-kettle/pull/5583.

Wingman will not be able to build this until the PR above is merged.

@bmorrise @mbatchelor @graimundo @pedrofvteixeira