### PR TITLE
[PDI-17436] Scheduling a transformation more than once causes the log…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiAction.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiAction.java
@@ -484,11 +484,12 @@ public class PdiAction implements IAction, IVarArgsAction, ILoggingAction, RowLi
       }
 
       try {
+        String carteObjectId = UUID.randomUUID().toString();
+        transMeta.setCarteObjectId( carteObjectId );
+
         localTrans = newTrans( transMeta );
         localTrans.setArguments( arguments );
         localTrans.shareVariablesWith( transMeta );
-        String carteObjectId = UUID.randomUUID().toString();
-        localTrans.setContainerObjectId( carteObjectId );
         CarteSingleton.getInstance().getTransformationMap().addTransformation( getTransformationName( carteObjectId ),
             carteObjectId, localTrans, new TransConfiguration( localTrans.getTransMeta(), transExConfig ) );
 
@@ -635,8 +636,8 @@ public class PdiAction implements IAction, IVarArgsAction, ILoggingAction, RowLi
   }
 
   @VisibleForTesting
-  Job newJob( Repository repository, JobMeta jobMeta, String carteObjectId ) {
-    return new Job( repository, jobMeta, carteObjectId );
+  Job newJob( Repository repository, JobMeta jobMeta ) {
+    return new Job( repository, jobMeta );
   }
 
   /**
@@ -746,7 +747,9 @@ public class PdiAction implements IAction, IVarArgsAction, ILoggingAction, RowLi
 
       try {
         String carteObjectId = UUID.randomUUID().toString();
-        localJob = newJob( repository, jobMeta, carteObjectId );
+        jobMeta.setCarteObjectId( carteObjectId );
+
+        localJob = newJob( repository, jobMeta );
         localJob.setArguments( arguments );
         localJob.shareVariablesWith( jobMeta );
         CarteSingleton.getInstance().getJobMap().addJob( getJobName( carteObjectId ), carteObjectId, localJob,

--- a/core/src/test/java/org/pentaho/platform/plugin/kettle/PdiActionTest.java
+++ b/core/src/test/java/org/pentaho/platform/plugin/kettle/PdiActionTest.java
@@ -416,7 +416,7 @@ public class PdiActionTest {
     action.setExpandingRemoteJob( TEST_FALSE_BOOLEAN_PARAM );
     action.setStartCopyName( TEST_START_COPY_NAME_PARAM );
 
-    doReturn( job ).when( action ).newJob( repository, meta, null );
+    doReturn( job ).when( action ).newJob( repository, meta );
     doReturn( false ).when( log ).isDebugEnabled();
     doReturn( jobExecutionConfiguration ).when( action ).newJobExecutionConfiguration();
     doReturn( result ).when( job ).getResult();


### PR DESCRIPTION
…s to display incorrectly

This reverts/reworks some of the work done in https://github.com/pentaho/pdi-platform-plugin/pull/61 and includes the same fix for transformations.

Merge this after: https://github.com/pentaho/pentaho-kettle/pull/5598

@cravobranco @ricardosilva88 