### PR TITLE
[PDI-18283] pdi.log: Excuting Jobs/Transformation using Slave Server results to Jobs/Transformation name as null along with duplicate entries.

### DIFF
--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiLifecycleListener.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiLifecycleListener.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
 */
 
 package org.pentaho.platform.plugin.kettle;
@@ -28,7 +28,6 @@ public class PdiLifecycleListener implements IPluginLifecycleListener {
   public void init() throws PluginLifecycleException {
     try {
       KettleSystemListener.environmentInit( null );
-      KettleLogStore.getAppender().addLoggingEventListener( new Slf4jLoggingEventListener() );
     } catch ( KettleException e ) {
       throw new PluginLifecycleException( e );
     }


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins

* [PDI-18283] Removing the initialization of the Slf4jLoggingEventListener, this is handled in the KettleSystemListener.environmentInit (it ends up initializing the KettleClientEnvironment which handles this logger initialization)
* [PDI-18283] Updating license year