### PR TITLE
[PDI-17983] pdi.log: Excuting Jobs/Transformation using Slave Server results to Jobs/Transformation name as null along with duplicate entries.

### DIFF
--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiLifecycleListener.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiLifecycleListener.java
@@ -18,8 +18,6 @@
 package org.pentaho.platform.plugin.kettle;
 
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.logging.KettleLogStore;
-import org.pentaho.di.core.logging.Slf4jLoggingEventListener;
 import org.pentaho.platform.api.engine.IPluginLifecycleListener;
 import org.pentaho.platform.api.engine.PluginLifecycleException;
 


### PR DESCRIPTION
@tatooine @pentaho-lmartins @smmribeiro 

Note: applied this in the 8.3 Branch, Sonar did not bring up issues with checkstyle/code smell. This should have triggered an issue but did not. Noticed it when Wingman 1.0 caught it, applied it in the 8.3 branch for the backport, then came back to fix it in master here.

* [PDI-17983] Fixing styling issue, removing unused imports