### PR TITLE
[BISERVER-15176] reverting the changes from BISERVER-15051 - Revert "[BISERVER-15051] hide internal variables PUC side, adding thi…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiContentProvider.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiContentProvider.java
@@ -20,7 +20,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.parameters.DuplicateParamException;
 import org.pentaho.di.core.parameters.NamedParams;
@@ -134,10 +133,5 @@ public class PdiContentProvider implements IPdiContentProvider {
   private boolean isEmpty( NamedParams np ) {
     return np == null || np.listParameters() == null || np.listParameters().length == 0;
 
-  }
-
-  @Override
-  public String getHideInternalVariable(){
-    return System.getProperty( Const.HIDE_INTERNAL_VARIABLES, Const.HIDE_INTERNAL_VARIABLES_DEFAULT );
   }
 }


### PR DESCRIPTION
…s here because of new method added to the interface IPdiContentProvider"

This reverts commit 81e82783b6cbe7b77ee6299990919ef420f2fdde.