### PR TITLE
feat: add description property to authorization actions [PPUC-64]

### DIFF
--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/security/policy/rolebased/actions/RepositoryExecuteAction.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/security/policy/rolebased/actions/RepositoryExecuteAction.java
@@ -9,6 +9,7 @@
  *
  * Change Date: 2029-07-20
  ******************************************************************************/
+
 package org.pentaho.platform.plugin.kettle.security.policy.rolebased.actions;
 
 import java.util.ResourceBundle;
@@ -19,15 +20,14 @@ import org.pentaho.platform.security.policy.rolebased.actions.AbstractAuthorizat
 public class RepositoryExecuteAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.repository.execute";
   ResourceBundle resourceBundle;
-  
+
   @Override
   public String getName() {
     return NAME;
   }
 
   @Override
-  public String getLocalizedDisplayName(String localeString) {
-    return Messages.getInstance().getString(NAME);
+  public String getLocalizedDisplayName( String localeString ) {
+    return Messages.getInstance().getString( NAME );
   }
-
 }

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/security/policy/rolebased/actions/RepositoryExecuteAction.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/security/policy/rolebased/actions/RepositoryExecuteAction.java
@@ -12,14 +12,11 @@
 
 package org.pentaho.platform.plugin.kettle.security.policy.rolebased.actions;
 
-import java.util.ResourceBundle;
-
 import org.pentaho.platform.plugin.kettle.messages.Messages;
 import org.pentaho.platform.security.policy.rolebased.actions.AbstractAuthorizationAction;
 
 public class RepositoryExecuteAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.repository.execute";
-  ResourceBundle resourceBundle;
 
   @Override
   public String getName() {
@@ -29,5 +26,10 @@ public class RepositoryExecuteAction extends AbstractAuthorizationAction {
   @Override
   public String getLocalizedDisplayName( String localeString ) {
     return Messages.getInstance().getString( NAME );
+  }
+
+  @Override
+  public String getLocalizedDescription( String localeString ) {
+    return Messages.getInstance().getString( NAME + ".description" );
   }
 }


### PR DESCRIPTION
This pull request makes a minor update to the `RepositoryExecuteAction` class by adding a new method for retrieving a localized description and removing an unused `ResourceBundle` field.

### Key changes:

**Enhancements to functionality:**
* Added the `getLocalizedDescription(String localeString)` method to provide a localized description for the `RepositoryExecuteAction` class. This method retrieves the description from the `Messages` resource bundle using the action's name appended with `.description`.

**Code cleanup:**
* Removed the unused `ResourceBundle` field from the `RepositoryExecuteAction` class to simplify the code.

should be merged after https://github.com/pentaho/pentaho-platform/pull/5911

@pentaho/millenniumfalcon please review