### PR TITLE
feat: add descriptions for authorization actions [PPUC-64]

### DIFF
--- a/core/src/main/resources/org/pentaho/platform/plugin/kettle/messages/messages.properties
+++ b/core/src/main/resources/org/pentaho/platform/plugin/kettle/messages/messages.properties
@@ -18,6 +18,7 @@ PdiAction.STATUS_ERRORS_DESC=The file processed, but there were errors. Please c
 PdiAction.STATUS_NOT_RUN_HEADING=Unable to run
 PdiAction.STATUS_NOT_RUN_DESC=Check the source file and try again.
 org.pentaho.repository.execute=Execute
+org.pentaho.repository.execute.description=Allows execution of Pentaho Data Integration transformations (.ktr) and jobs (.kjb), either directly or via schedules.
 PdiAction.LOG_OVERRIDE_GATHER_METRICS=Overriding the Gather Metrics configuration with [{0}].
 PdiAction.LOG_OVERRIDE_SAFE_MODE=Overriding the Safe Mode configuration with [{0}].
 PdiAction.LOG_OVERRIDE_LOG_LEVEL=Overriding the Log Level configuration with [{0}].


### PR DESCRIPTION
This pull request introduces a small addition to the `messages.properties` file to provide a description for the `org.pentaho.repository.execute` property.

@pentaho/millenniumfalcon please review