### PR TITLE
DEVO-14154: license/copyright rebrand

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Pentaho Developer Edition 10.3 Copyright 2024 Hitachi Vantara, LLC; licensed under the 
+Pentaho Developer Edition 11.0 Copyright 2026 Pentaho Canada Inc.; licensed under the 
 Business Source License 1.1 (BSL). This project may include third party components that
 are individually licensed per the terms indicated by their respective copyright owners
 included in text file or in the source code. 
@@ -8,9 +8,9 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 
 Parameters
 
-Licensor:             Hitachi Vantara, LLC.
-Licensed Work:        Pentaho Developer Edition 10.3. The Licensed Work is (c) 2024
-                      Hitachi Vantara, LLC.
+Licensor:             Pentaho Canada Inc.
+Licensed Work:        Pentaho Developer Edition 11.0. The Licensed Work is (c) 2026
+                      Pentaho Canada Inc.
 Additional Use Grant: None
 Change Date:          Four years from the date the Licensed Work is published.
 Change License:       Apache 2.0

--- a/assemblies/plugin/pom.xml
+++ b/assemblies/plugin/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/assemblies/plugin/src/assembly/assembly.xml
+++ b/assemblies/plugin/src/assembly/assembly.xml
@@ -1,3 +1,14 @@
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">

--- a/assemblies/plugin/src/main/resources/plugin.spring.xml
+++ b/assemblies/plugin/src/main/resources/plugin.spring.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:pen="http://www.pentaho.com/schema/pentaho-system"

--- a/assemblies/plugin/src/main/resources/plugin.xml
+++ b/assemblies/plugin/src/main/resources/plugin.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 
 <plugin title="${title-pdi-platform-plugin}" name="pdi-platform-plugin"
         description="${description-pdi-platform-plugin}" resourcebundle="resources/messages">

--- a/assemblies/plugin/src/main/resources/settings.xml
+++ b/assemblies/plugin/src/main/resources/settings.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <settings>
 
   <!-- Use the following to force the behaviour of the "gathering metrics"

--- a/assemblies/plugin/src/main/resources/version.xml
+++ b/assemblies/plugin/src/main/resources/version.xml
@@ -1,2 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <version>${project.version}</version>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/core/repositories.xml
+++ b/core/repositories.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <repositories>
 
   <!-- This is a filesystem-based repository; used in PdiActionTest class for conducting its tests using /test-src/solution/pdi/*.ktr -->

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/EngineMetaLoader.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/EngineMetaLoader.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/LoggingBufferAppender.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/LoggingBufferAppender.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/ParameterContentGenerator.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/ParameterContentGenerator.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/ParameterUIContentGenerator.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/ParameterUIContentGenerator.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 package org.pentaho.platform.plugin.kettle;
 
 import java.io.InputStream;

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiAction.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiAction.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiContentGenerator.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiContentGenerator.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiContentProvider.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiContentProvider.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 package org.pentaho.platform.plugin.kettle;
 
 import java.util.ArrayList;

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiService.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiService.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiServiceResult.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/PdiServiceResult.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/PlatformKettleDataSourceProvider.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/PlatformKettleDataSourceProvider.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/messages/Messages.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/messages/Messages.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle.messages;

--- a/core/src/main/java/org/pentaho/platform/plugin/kettle/security/policy/rolebased/actions/RepositoryExecuteAction.java
+++ b/core/src/main/java/org/pentaho/platform/plugin/kettle/security/policy/rolebased/actions/RepositoryExecuteAction.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 package org.pentaho.platform.plugin.kettle.security.policy.rolebased.actions;
 

--- a/core/src/test/java/org/pentaho/platform/plugin/kettle/ParameterContentGeneratorTest.java
+++ b/core/src/test/java/org/pentaho/platform/plugin/kettle/ParameterContentGeneratorTest.java
@@ -1,15 +1,15 @@
-/*
- * ! ******************************************************************************
+/*! ******************************************************************************
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/test/java/org/pentaho/platform/plugin/kettle/PdiActionTest.java
+++ b/core/src/test/java/org/pentaho/platform/plugin/kettle/PdiActionTest.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/test/java/org/pentaho/platform/plugin/kettle/PdiContentGeneratorTest.java
+++ b/core/src/test/java/org/pentaho/platform/plugin/kettle/PdiContentGeneratorTest.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/test/java/org/pentaho/platform/plugin/kettle/PlatformKettleDataSourceProviderTest.java
+++ b/core/src/test/java/org/pentaho/platform/plugin/kettle/PlatformKettleDataSourceProviderTest.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 

--- a/core/src/test/java/org/pentaho/platform/plugin/kettle/StubUserDetailService.java
+++ b/core/src/test/java/org/pentaho/platform/plugin/kettle/StubUserDetailService.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/test/java/org/pentaho/platform/plugin/kettle/StubUserRoleListService.java
+++ b/core/src/test/java/org/pentaho/platform/plugin/kettle/StubUserRoleListService.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;

--- a/core/src/test/java/org/pentaho/platform/plugin/kettle/UserParametersTest.java
+++ b/core/src/test/java/org/pentaho/platform/plugin/kettle/UserParametersTest.java
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 
 package org.pentaho.platform.plugin.kettle;


### PR DESCRIPTION
Automated license header and brand update (see update-reports/). Generated and locally validated by updater.py, published by publish_branches.py.